### PR TITLE
add a total supply cli feature

### DIFF
--- a/src/ctc/cli/cli_run.py
+++ b/src/ctc/cli/cli_run.py
@@ -76,6 +76,7 @@ command_index_by_category: dict[str, toolcli.CommandIndex] = {
         ('erc20',): 'ctc.cli.commands.data.erc20_command',
         ('erc20', 'balance'): 'ctc.cli.commands.data.erc20.balance_command',
         ('erc20', 'balances'): 'ctc.cli.commands.data.erc20.balances_command',
+        ('erc20', 'supply'): 'ctc.cli.commands.data.erc20.total_supply_command',
         ('erc20', 'transfers'): 'ctc.cli.commands.data.erc20.transfers_command',
         ('events',): 'ctc.cli.commands.data.events_command',
         ('gas',): 'ctc.cli.commands.data.gas_command',

--- a/src/ctc/cli/commands/data/erc20/balances_command.py
+++ b/src/ctc/cli/commands/data/erc20/balances_command.py
@@ -284,7 +284,7 @@ async def async_balances_command(
             print()
             print()
             toolstr.print(
-                toolstr.hjustify('ETH balance over time', 'center', 70),
+                toolstr.hjustify('ERC20 balance over time', 'center', 70),
                 indent=4,
                 style=styles['title'],
             )

--- a/src/ctc/cli/commands/data/erc20/total_supply_command.py
+++ b/src/ctc/cli/commands/data/erc20/total_supply_command.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import typing
+
+import toolcli
+import toolstr
+
+import ctc.config
+from ctc import cli
+from ctc import evm
+from ctc import spec
+from ctc.cli import cli_utils
+
+
+command_help = """output ERC20 total supply of blocks"""
+
+
+def get_command_spec() -> toolcli.CommandSpec:
+    return {
+        'f': async_total_supply_command,
+        'help': command_help,
+        'args': [
+            {'name': 'erc20', 'help': 'address of ERC20 token'},
+            {
+                'name': '--blocks',
+                'nargs': '+',
+                'help': 'block numbers to get total supply at',
+            },
+            #
+            {
+                'name': '--raw',
+                'action': 'store_true',
+                'help': 'whether to skip normalizing by ERC20 decimals',
+            },
+            {
+                'name': '--export',
+                'default': 'stdout',
+                'help': 'file path for output (.json or .csv)',
+            },
+            {
+                'name': '--overwrite',
+                'action': 'store_true',
+                'help': 'specify that output path can be overwritten',
+            },
+            {'name': '-n', 'help': 'show n data points', 'type': int},
+        ],
+        'examples': {
+            '0x956f47f50a910163d8bf957cf5846d573e7f87ca 0x9928e4046d7c6513326ccea028cd3e7a91c7590a --blocks 14000000:14000100',
+            '0x956f47f50a910163d8bf957cf5846d573e7f87ca 0x9928e4046d7c6513326ccea028cd3e7a91c7590a --blocks 14000000:14000100 --raw'
+        },
+    }
+
+
+async def async_total_supply_command(
+    *,
+    erc20: spec.Address,    
+    blocks: typing.Sequence[str],
+    raw: bool,
+    export: str,
+    overwrite: bool,
+    n: int | None,
+) -> None:
+
+    import polars as pl
+
+    resolved_blocks = await cli_utils.async_parse_block_slice(blocks, n=n)
+
+    timestamps = await evm.async_get_block_timestamps(resolved_blocks)
+
+    erc20 = await evm.async_resolve_address(
+        erc20, block=resolved_blocks[-1]
+    )
+    total_supplies = await evm.async_get_erc20_total_supply_by_block(
+        token=erc20,
+        blocks=resolved_blocks,
+        normalize=(not raw)
+    )
+
+    if export == 'stdout':
+        styles = cli.get_cli_styles()
+
+        # print header
+        toolstr.print_text_box(
+            'Historical ERC20 Total Supply', style=styles['title']
+        )
+        print()
+        toolstr.print_table(
+            rows=[['token', erc20]],
+            column_justify=['right', 'left'],
+            border=styles['comment'],
+            column_styles=[styles['option'], styles['metavar']],
+        )
+
+        import tooltime
+
+        # print balance history table
+        print()
+        print()
+        rows = []
+        for block, timestamp, total_supply in zip(resolved_blocks, timestamps, total_supplies):
+            age = tooltime.get_age(timestamp, 'TimelengthPhrase')
+            age = ', '.join(age.split(', ')[:1])
+            row = [tooltime.timestamp_to_iso(timestamp), age, block, total_supply]
+            rows.append(row)
+        labels = ['timestamp', 'age', 'block', 'total supply']
+        if n is None:
+            n = 21
+        toolstr.print_table(
+            rows,
+            labels=labels,
+            border=styles['comment'],
+            label_style=styles['title'],
+            column_formats={'balance': {'order_of_magnitude': True, 'trailing_zeros': True}},
+            column_styles={
+                'balance': styles['description'] + ' bold',
+            },
+            # indent=4,
+            limit_rows=n,
+        )
+
+        # print balance history chart
+        def formatter(xval: typing.Any) -> str:
+            return toolstr.format(round(xval))
+
+        xvals = resolved_blocks
+        yvals = total_supplies
+        plot = toolstr.render_line_plot(
+            xvals=xvals,
+            yvals=yvals,
+            n_rows=10,
+            n_columns=60,
+            line_style=styles['description'],
+            chrome_style=styles['comment'],
+            tick_label_style=styles['metavar'],
+            xaxis_kwargs={'formatter': formatter},
+            char_dict=ctc.config.get_cli_chart_charset(),
+        )
+        print()
+        print()
+        toolstr.print(
+            toolstr.hjustify('ERC20 total supply over time', 'center', 70),
+            indent=4,
+            style=styles['title'],
+        )
+        toolstr.print(plot, indent=4)
+
+        return
+
+    else:
+        df = pl.DataFrame({'balance': total_supply, 'block': resolved_blocks})
+        output_data = df
+
+
+    cli_utils.output_data(
+        output_data,
+        output=export,
+        overwrite=overwrite,
+        top=n
+    )


### PR DESCRIPTION
Adds a total supply cli subcommand for ERC20s over a number of blocks

Also fixes a typo in erc20 balances subcommand

Sample output: 
```
➜  src git:(total_supply_cli) py3 ctc erc20 supply 0x956f47f50a910163d8bf957cf5846d573e7f87ca --blocks 15589234:18257202:100000
┌───────────────────────────────┐
│ Historical ERC20 Total Supply │
└───────────────────────────────┘

  token  │  0x956f47f50a910163d8bf957cf5846d573e7f87ca


             timestamp  │       age  │       block  │   total supply
────────────────────────┼────────────┼──────────────┼─────────────────
  2022-09-22T13:39:23Z  │   1 years  │  15,589,234  │  99,364,749.69
  2022-10-06T13:03:35Z  │  360 days  │  15,689,234  │  60,141,472.83
  2022-10-20T12:13:11Z  │  346 days  │  15,789,234  │  56,725,676.85
  2022-11-03T11:34:59Z  │  332 days  │  15,889,234  │  48,509,688.99
  2022-11-17T10:45:47Z  │  318 days  │  15,989,234  │  49,791,310.52
  2022-12-01T10:03:11Z  │  304 days  │  16,089,234  │  50,843,535.22
  2022-12-15T09:35:11Z  │  290 days  │  16,189,234  │  45,508,825.45
  2022-12-29T08:30:47Z  │  276 days  │  16,289,234  │   41,181,640.4
  2023-01-12T07:28:47Z  │  262 days  │  16,389,234  │  38,325,147.46
  2023-01-26T06:35:23Z  │  248 days  │  16,489,234  │  39,196,069.78
                   ...  │       ...  │         ...  │            ...
  2023-06-01T23:33:35Z  │  121 days  │  17,389,234  │  34,539,943.51
  2023-06-16T01:47:59Z  │  107 days  │  17,489,234  │  34,564,908.21
  2023-06-30T02:50:47Z  │   93 days  │  17,589,234  │  34,681,949.23
  2023-07-14T04:08:47Z  │   79 days  │  17,689,234  │  35,096,185.42
  2023-07-28T04:41:23Z  │   65 days  │  17,789,234  │  35,096,185.42
  2023-08-11T04:23:35Z  │   51 days  │  17,889,234  │  35,096,186.42
  2023-08-25T04:09:47Z  │   37 days  │  17,989,234  │  35,096,186.42
  2023-09-08T04:11:11Z  │   23 days  │  18,089,234  │  16,990,836.09
  2023-09-22T05:12:59Z  │    9 days  │  18,189,234  │  17,253,345.24
  2023-10-01T17:33:35Z  │   1 hours  │  18,257,202  │  17,304,946.81


                         ERC20 total supply over time
     102.7M╶┐⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
            │⡆⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
            │⠸⡀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
      73.0M╶┤⠀⢇⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
            │⠀⠘⣄⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
            │⠀⠀⠀⠉⠑⠢⢄⣀⣀⣀⠤⢄⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
      43.4M╶┤⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠉⠒⠢⠤⣀⠀⠀⣀⣀⣀⣀⣀⣀⣀⣀⣀⠤⠤⠤⢄⡀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
            │⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠉⠉⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠈⠑⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⡄⠀⠀⠀⠀⠀
            │⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠈⢢⠀⠀⠀⠀
      13.7M╶┘⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠉⠉⠉⠉
             ┌─────────────────────────────┬────────────────────────────┐
             ╵                             ╵                            ╵
             15,589,234                16,945,451              18,257,202
```